### PR TITLE
When there is an error, no longer reject twice and crash when checking nonexistant res.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -82,9 +82,7 @@ function OoyalaApiClient( apiKey, apiSecret ) {
 			.end( function( err, res ) {
 				if ( err ) {
 					deferred.reject( new Error( err ) );
-				}
-
-				if ( res.message ) {
+				} else if ( res.message ) {
 					deferred.reject( new Error( res.message ) );
 				} else {
 					deferred.resolve(res.body);


### PR DESCRIPTION
When there is an error, no longer reject twice and crash when checking nonexistant res.
